### PR TITLE
downgrading to dotnet core 3.0 cause 3.1 is unsupported at this time

### DIFF
--- a/TodoApi/TodoApi.csproj
+++ b/TodoApi/TodoApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
don't think azure is quite ready for 3.1 so downgrading to 3.0 to see if Kudu build works with it instead